### PR TITLE
OPD-1966: Updated kafka-cruise-control-start.sh start script

### DIFF
--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -15,7 +15,7 @@ else
   CYGWIN=0
 fi
 
-base_dir=/usr/odp/current/cruise-control
+base_dir=/usr/odp/current/cruise-control3
 
 if [ -z "$SCALA_VERSION" ]; then
   SCALA_VERSION=2.13.6


### PR DESCRIPTION
This patch was tested locally.