### PR TITLE
OSV-7804 | CVE-2022-36944, Upgraded scala version to 2.13.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-scalaVersion=2.13.5
+scalaVersion=2.13.9
 kafkaVersion=2.8.2.3.2.3.4-2001
 zookeeperVersion=3.5.10.3.2.3.4-2001
 nettyVersion=4.1.73.Final


### PR DESCRIPTION
https://accelcentral.atlassian.net/browse/OSV-7804