### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xms512m -Xmx512m
 scalaVersion=2.13.9
 kafkaVersion=2.8.2.3.2.3.6-2
 zookeeperVersion=3.5.10.3.2.3.6-2
-nettyVersion=4.1.73.Final
+nettyVersion=4.1.132.Final
 jettyVersion=9.4.44.v20210927


### PR DESCRIPTION
This patch was tested locally.