### PR TITLE
ODP-6881: Remove JAVA_HOME settings from source code

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -62,10 +62,6 @@
 #
 ##############################################################################
 
-#Set JAVA_HOME to JAVA 11
-export JAVA_HOME=/usr/lib/jvm/java-11
-
-
 # Attempt to set APP_HOME
 
 # Resolve links: $0 may be a link


### PR DESCRIPTION
JAVA_HOME to be set as a configuration in the build system

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR>.
